### PR TITLE
Add oracle java jai imageio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
-FROM tomcat:8.0
+FROM ubuntu:14.04
 MAINTAINER Tim Sutton<tim@linfiniti.com>
 
 RUN  export DEBIAN_FRONTEND=noninteractive
 ENV  DEBIAN_FRONTEND noninteractive
 RUN  dpkg-divert --local --rename --add /sbin/initctl
-#RUN  ln -s /bin/true /sbin/initctl
 
 # Use local cached debs from host (saves your bandwidth!)
 # Change ip below to that of your apt-cacher-ng host
@@ -13,6 +12,38 @@ RUN  dpkg-divert --local --rename --add /sbin/initctl
 ADD 71-apt-cacher-ng /etc/apt/apt.conf.d/71-apt-cacher-ng
 
 RUN apt-get -y update
+
+#-------------Install Java-------------#
+RUN apt-get install -y wget unzip software-properties-common python-software-properties
+
+RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+    add-apt-repository -y ppa:webupd8team/java && \
+    apt-get update && \
+    apt-get install -y oracle-java7-installer && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/oracle-jdk7-installer
+
+ENV JAVA_HOME /usr/lib/jvm/java-7-oracle
+
+#-------------Install Tomcat and JAI/ImageIO--------#
+RUN apt-get update && apt-get install -y tomcat7
+
+WORKDIR /tmp
+RUN wget http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz && \
+    wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
+    gunzip -c jai-1_1_3-lib-linux-amd64.tar.gz | tar xf - && \
+    gunzip -c jai_imageio-1_1-lib-linux-amd64.tar.gz | tar xf - && \
+    mv /tmp/jai-1_1_3/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
+    mv /tmp/jai-1_1_3/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
+    mv /tmp/jai_imageio-1_1/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
+    mv /tmp/jai_imageio-1_1/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
+    rm /tmp/jai-1_1_3-lib-linux-amd64.tar.gz && \
+    rm -r /tmp/jai-1_1_3 && \
+    rm /tmp/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
+    rm -r /tmp/jai_imageio-1_1
+
+ENV GEOSERVER_DATA_DIR /opt/geoserver/data_dir
+ENV GEOSERVER_HOME /var/lib/tomcat7/webapps/geoserver
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
@@ -30,18 +61,24 @@ RUN if [ ! -f /tmp/resources/geoserver.zip ]; then \
 	-O /tmp/resources/geoserver.zip; \
     fi; \
     unzip /tmp/resources/geoserver.zip -d /tmp/geoserver \
-    && mv /tmp/geoserver/geoserver.war /usr/local/tomcat/webapps/geoserver.war \
-    && unzip /usr/local/tomcat/webapps/geoserver.war -d /usr/local/tomcat/webapps/geoserver \
+    && mv /tmp/geoserver/geoserver.war /var/lib/tomcat7/webapps/geoserver.war \
+    && unzip /var/lib/tomcat7/webapps/geoserver.war -d /var/lib/tomcat7/webapps/geoserver \
     && rm -rf /tmp/geoserver
 
 # Install any plugin zip files in resources/plugins
 RUN if ls /tmp/resources/plugins/*.zip > /dev/null 2>&1; then \
       for p in /tmp/resources/plugins/*.zip; do \
         unzip $p -d /tmp/gs_plugin \
-        && mv /tmp/gs_plugin/*.jar /usr/local/tomcat/webapps/geoserver/WEB-INF/lib/ \
+        && mv /tmp/gs_plugin/*.jar /var/lib/tomcat7/webapps/geoserver/WEB-INF/lib/ \
         && rm -rf /tmp/gs_plugin; \
       done; \
     fi
 
+# Set up files for supervisor to run tomcat
+RUN apt-get install -y supervisor
+RUN \cp /tmp/resources/supervisord.conf /etc/supervisor/conf.d/
+RUN \cp /tmp/resources/startup.sh /usr/local/bin/startup.sh
+
 # Delete resources after installation
 RUN rm -rf /tmp/resources
+

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ container do:
 
 ```
 sudo docker run --name "postgis" -d -t kartoza/postgis
-sudo docker run --name "geoserver"  --link postgis:postgis -p 8080:8080 -d -t kartoza/geoserver
+sudo docker run --name "geoserver"  --link postgis:postgis -p 8080:8080 -d -t kartoza/geoserver /usr/local/bin/startup.sh
 ```
+
+You can set JAVA_OPTS by including something like this: `-e "JAVA_OPTS=-Xms2048m -Xmx2048m -XX:MaxPermSize=128m -server -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseParallelGC" \`
 
 You can also use the following environment variables to pass a 
 user name and password. To postgis:

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-if [ ! -f resources/geoserver.zip ]
-then
-    wget -c http://downloads.sourceforge.net/project/geoserver/GeoServer/2.5.2/geoserver-2.5.2-bin.zip -O resources/geoserver.zip
-fi
 docker build -t kartoza/geoserver .

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#A bit of a hack to push the JAVA_OPTS into the right file.
+eval echo 'JAVA_OPTS=\"$JAVA_OPTS\"' >> /etc/default/tomcat7
+
+# Start with supervisor -----------------------------------------------------------------------------------------------#
+/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/resources/supervisord.conf
+++ b/resources/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:tomcat7]
+command=/etc/init.d/tomcat7 start
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+exitcodes=0,1,2

--- a/run.sh
+++ b/run.sh
@@ -18,4 +18,6 @@ docker run \
         -v $DATA_DIR:/opt/geoserver/data_dir \
 	-p 8080:8080 \
 	-d \
-	-t kartoza/geoserver
+	-e "JAVA_OPTS=-Xms2048m -Xmx2048m -XX:MaxPermSize=128m -server -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseParallelGC" \
+	-t kartoza/geoserver \
+	/usr/local/bin/startup.sh


### PR DESCRIPTION
Hey, I updated this to use the methodology that I ended up with for my production GeoServer setup.

It uses Oracle Java, which is faster, and includes ImageIO and JAI extensions for Java.

It also used Supervisor to run Tomcat, which restarts it when it crashes.

Feel free to ignore it or include it. I tested it and it all works. Up to you if you want to pull it in.
