### PR TITLE
Remove build sh geoserver zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,22 @@ RUN if ls /var/cache/oracle-jdk7-installer/*jdk-*-linux-x64.tar.gz > /dev/null 2
        fi; \
     fi;
 
+#Add JAI and ImageIO for great speedy speed.
+WORKDIR /tmp
+RUN wget http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz && \
+    wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
+    gunzip -c jai-1_1_3-lib-linux-amd64.tar.gz | tar xf - && \
+    gunzip -c jai_imageio-1_1-lib-linux-amd64.tar.gz | tar xf - && \
+    mv /tmp/jai-1_1_3/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
+    mv /tmp/jai-1_1_3/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
+    mv /tmp/jai_imageio-1_1/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
+    mv /tmp/jai_imageio-1_1/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
+    rm /tmp/jai-1_1_3-lib-linux-amd64.tar.gz && \
+    rm -r /tmp/jai-1_1_3 && \
+    rm /tmp/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
+    rm -r /tmp/jai_imageio-1_1
+WORKDIR $CATALINA_HOME
+
 # A little logic that will fetch the geoserver war zip file if it
 # is not available locally in the resources dir
 RUN if [ ! -f /tmp/resources/geoserver.zip ]; then \

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-if [ ! -f resources/geoserver.zip ]
-then
-    wget -c http://downloads.sourceforge.net/project/geoserver/GeoServer/2.5.2/geoserver-2.5.2-bin.zip -O resources/geoserver.zip
-fi
 docker build -t kartoza/geoserver .


### PR DESCRIPTION
This doesn’t make sense as there is different logic in the Dockerfile
for the geoserver version.
